### PR TITLE
Add output formats and options; test use as a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ parameters for that. Presumably that's not too bad a problem.
 
 ## Installation
 
-To use it from the command line, type:
+To use it **from the command line**, type:
 ```bash
 $ npm install -g echidna-manifester
 ```
 
-To use as a Node.js module, add it to your `package.json` file:
+To use **as a Node.js module**, add it to your `package.json` file:
 ```javascript
 "dependencies": {
     ⋮
@@ -46,7 +46,7 @@ var em = require('echidna-manifester');
 
 ## Usage
 
-From the command line, invoke it with these arguments:
+**From the command line**, invoke it with these arguments:
 ```bash
 $ echidna-manifester <PATH/TO/FILE> [OPTIONS-AS-JSON]
 ```
@@ -58,7 +58,7 @@ $ echidna-manifester /tmp/spec.html '{"format": "plain"}'
 $ echidna-manifester https://foo.com/bar.html '{"includeErrors": true, "includeTypes": true}'
 ```
 
-As a Node.js module: `echidna-manifester` exports only one function: `run`.
+**As a Node.js module**: `echidna-manifester` exports only one function: `run`.
 
 ```javascript
 var em = require('echidna-manifester');
@@ -96,7 +96,7 @@ The object `options` may include these properties (default values are **in bold*
 
 ### Examples
 
-These examples use this dummy spec:  
+All these examples use this dummy spec:  
 [`http://www.w3.org/People/Antonio/spec/dummy-spec.html`](http://www.w3.org/People/Antonio/spec/dummy-spec.html)
 
 Use from the command line, with default options:
@@ -120,11 +120,10 @@ em.run(
         "format":        "json",
         "includeErrors": true
     },
-    doStuffWithData
+    processJSON
 );
 ```
 
-Output:
 ```json
 {
     "ok": [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Some people (whose names shall remain a secret) complained that it could be too 
 What this tool does is load a file you give to it (local or URL) and try to list
 all the resources that it loads, and that are situated under the same directory as that file.
 
-In theory, if you've done things well (and your document can be published under TR without 
+In theory, if you've done things well (and your document can be published under TR without
 modification), then this should list all the dependencies you have that should go into your Echidna
 manifest. You can paste them there.
 
@@ -17,8 +17,8 @@ There are good reasons that this is not supported directly by Echidna. In the ge
 had a reliable process to detect all the resources that a Web page might load then you would have a
 solution to the Halting Problem.
 
-So keep in mind that this isn't perfect. For instance, if your document loads stuff that causes 
-other stuff to be loaded by script over time, it's possible that the process will time out before 
+So keep in mind that this isn't perfect. For instance, if your document loads stuff that causes
+other stuff to be loaded by script over time, it's possible that the process will time out before
 some resources are loaded, and so they won't get loaded. For specs that should not happen, but for
 instance if ReSpec+PhantomJS are being slow together you could be out of luck.
 
@@ -27,43 +27,38 @@ parameters for that. Presumably that's not too bad a problem.
 
 ## Installation
 
-### To use from the command line
-
+To use it from the command line, type:
 ```bash
-npm install -g echidna-manifester
+$ npm install -g echidna-manifester
 ```
 
-### To use as a library
-
-```json
-{
-  "dependencies": {
+To use as a Node.js module, add it to your `package.json` file:
+```javascript
+"dependencies": {
+    ⋮
     "echidna-manifest": "^0.1.0"
-  }
 }
 ```
-
+And *require* it as usual:
 ```javascript
 var em = require('echidna-manifester');
 ```
 
 ## Usage
 
-### From the command line
-
+From the command line, invoke it with these arguments:
 ```bash
 $ echidna-manifester <PATH/TO/FILE> [OPTIONS-AS-JSON]
 ```
 
-Examples:
-
+Some examples:
 ```bash
 $ echidna-manifester http://berjon.com/
 $ echidna-manifester /tmp/spec.html '{"format": "plain"}'
 $ echidna-manifester https://foo.com/bar.html '{"includeErrors": true, "includeTypes": true}'
 ```
 
-### As a library
+As a Node.js module: `echidna-manifester` exports only one function: `run`.
 
 ```javascript
 var em = require('echidna-manifester');
@@ -73,7 +68,7 @@ var options = {
     "compactUrls": false,
 };
 var callback = function(data) {
-    sendByEmail(data);
+    console.dir(data);
 };
 
 em.run(url, options, callback);
@@ -81,28 +76,32 @@ em.run(url, options, callback);
 
 ## Output formats and options
 
-The object `options` may include these properties (in **bold**, default values):
+The object `options` may include these properties (default values are **in bold**):
 
 * `'format'`:  
   {**`'manifest'`**, `'json'`, `'plain'`}  
-  ** `'manifest'`: format appropriate for an [Echidna](https://github.com/w3c/echidna) manifest (plain text)
-  ** `'json'`: JSON object
-  ** `'plain'`: plain text, one line per resource; fields: `URL status type`
+  * `'manifest'`: a format that is appropriate for an [Echidna](https://github.com/w3c/echidna) manifest (plain text)
+  * `'json'`: a JSON object
+  * `'plain'`: plain text, one line per resource, fields separated by spaces: `URL STATUS [TYPE]`
 * `'compactUrls'`  
   {**`true`**, `false`}  
-  Omit the beginning of the URL that is common to all resources
+  Omit the beginning of the URL
 * `'includeErrors'`  
   {`true`, **`false`**}  
   Whether resources that could *not* be loaded should be included in the output, too
 * `'includeTypes'`  
   {`true`, **`false`**}  
-  Add MIME metadata to idenfity the type of resource, if known (this parameter is ignored when the format is `'manifest'`)
+  Add a string to idenfity the type of resource (kind of MIME), if possible;  
+  this parameter is ignored when the format is `'manifest'`
 
 ### Examples
 
+These examples use this dummy spec:  
+[`http://www.w3.org/People/Antonio/spec/dummy-spec.html`](http://www.w3.org/People/Antonio/spec/dummy-spec.html)
+
+Use from the command line, with default options:
 ```bash
-$ node echidna-manifester \
-  http://www.w3.org/People/Antonio/spec/dummy-spec.html
+$ node echidna-manifester http://www.w3.org/People/Antonio/spec/dummy-spec.html
 dummy-spec.html
 foo.css
 baz.js
@@ -111,54 +110,41 @@ http://www.w3.org/2014/10/stdvidthumb.png
 bar.jpeg
 ```
 
+Invoke from JavaScript, specifying JSON output and failed resources too:
 ```javascript
-require('echidna-manifester').run(
+var em = require('echidna-manifester');
+
+em.run(
     'http://www.w3.org/People/Antonio/spec/dummy-spec.html',
-	{
-	    "format":        "json",
-		"includeErrors": true
-	},
-	doStuffWithData
+    {
+        "format":        "json",
+        "includeErrors": true
+    },
+    doStuffWithData
 );
 ```
 
+Output:
 ```json
 {
-  "ok": [
-    {
-      "url": "dummy-spec.html"
-    },
-    {
-      "url": "foo.css"
-    },
-    {
-      "url": "baz.js"
-    },
-    {
-      "url": "http://www.w3.org/Consortium/Offices/w3coffice.png"
-    },
-    {
-      "url": "http://www.w3.org/2014/10/stdvidthumb.png"
-    },
-    {
-      "url": "bar.jpeg"
-    }
-  ],
-  "error": [
-    {
-      "url": "i-do-not-exist.css"
-    },
-    {
-      "url": "i-do-not-exist.svg"
-    }
-  ]
+    "ok": [
+        {"url": "dummy-spec.html"},
+        {"url": "foo.css"},
+        {"url": "baz.js"},
+        {"url": "http://www.w3.org/Consortium/Offices/w3coffice.png"},
+        {"url": "http://www.w3.org/2014/10/stdvidthumb.png"},
+        {"url": "bar.jpeg"}
+    ],
+    "error": [
+        {"url": "i-do-not-exist.css"},
+        {"url": "i-do-not-exist.svg"}
+    ]
 }
 ```
 
+From the command line, in plain text, with full URLs and with types:
 ```bash
-$ node echidna-manifester \
-  http://www.w3.org/People/Antonio/spec/dummy-spec.html \
-  '{"format": "plain", "includeTypes": true, "compactUrls": false}'
+$ node echidna-manifester http://www.w3.org/People/Antonio/spec/dummy-spec.html '{"format": "plain", "includeTypes": true, "compactUrls": false}'
 http://www.w3.org/People/Antonio/spec/dummy-spec.html ok html
 http://www.w3.org/People/Antonio/spec/foo.css ok css
 http://www.w3.org/People/Antonio/spec/baz.js ok js

--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@ $ echidna-manifester /tmp/spec.html '{"format": "plain"}'
 $ echidna-manifester https://foo.com/bar.html '{"includeErrors": true, "includeTypes": true}'
 ```
 
-**As a Node.js module**: `echidna-manifester` exports only one function: `run`.
+**As a Node.js module**: `echidna-manifester` exports only one function, `run`.
+These are its arguments:
+
+1. `url` (`String`): required
+2. `options` (`Object`): optional.  
+  If absent, default options will be applied.
+3. `callback` (`Function`): optional.  
+  Signature: `function(data)`.  
+  If absent, the output will be `console.log`ged.
 
 ```javascript
 var em = require('echidna-manifester');
@@ -80,9 +88,9 @@ The object `options` may include these properties (default values are **in bold*
 
 * `'format'`:  
   {**`'manifest'`**, `'json'`, `'plain'`}  
-  * `'manifest'`: a format that is appropriate for an [Echidna](https://github.com/w3c/echidna) manifest (plain text)
+  * `'manifest'`: a format that is appropriate for an [Echidna](https://github.com/w3c/echidna) manifest
   * `'json'`: a JSON object
-  * `'plain'`: plain text, one line per resource, fields separated by spaces: `URL STATUS [TYPE]`
+  * `'plain'`: text, one line per resource, fields separated by spaces: `URL STATUS [TYPE]`
 * `'compactUrls'`  
   {**`true`**, `false`}  
   Omit the beginning of the URL

--- a/echidna-manifester.js
+++ b/echidna-manifester.js
@@ -1,37 +1,165 @@
 #!/usr/bin/env node
 
+'use strict';
+
+// Pseudo-constants:
+var DEFAULT_OPTIONS = {
+    "format":        "manifest"
+,   "compactUrls":   true
+,   "includeErrors": false
+,   "includeTypes":  false
+};
+
+// “Global” variables:
 var Nightmare = require("nightmare")
 ,   phantomjs = require("phantomjs")
-,   pth = require("path")
-,   u = require("url")
-,   seen = {}
+,   pth       = require("path")
+,   u         = require("url")
+,   document
+,   baseUrl
+,   options
+,   callback
+,   found
+,   failed
+,   pending
 ;
 
-exports.run = function (loadURL) {
-    var nm = new Nightmare({
-        phantomPath:    pth.dirname(phantomjs.path) + "/"
-    });
-    
-    nm.on("resourceRequested", function (res) {
-        var url = u.parse(res.url)
-        ,   baseDir = loadURL.replace(/[^\/]*$/, "")
-        ;
-        if (seen[url.href]) return;
-        seen[url.href] = true;
-        if (url.href.indexOf(baseDir) === 0) {
-            var loaded = url.href.replace(baseDir, "");
-            if (loaded) console.log(loaded);
+var dumpResult = function() {
+    var result
+    ,   i
+    ,   j
+    ;
+    if ("manifest" === options.format) {
+        result = '';
+        for (i in found) {
+            if (options.compactUrls) result += found[i].compactUrl + '\n';
+            else                     result += i + '\n';
         }
+        if (options.includeErrors) {
+            for (i in failed) {
+                if (options.compactUrls) result += failed[i].compactUrl + '\n';
+                else                     result += i + '\n';
+            }
+        }
+        if (callback) {
+            callback(result);
+        } else {
+            console.log(result);
+        }
+    } else if ("json" === options.format) {
+        result = {ok: []};
+        for (i in found) {
+            j = {};
+            if (options.compactUrls)  j.url = found[i].compactUrl;
+            else                      j.url = i;
+            if (options.includeTypes) j.type = found[i].type;
+            result.ok.push(j);
+        }
+        if (options.includeErrors) {
+            result.error = [];
+            for (i in failed) {
+                j = {};
+                if (options.compactUrls)  j.url = failed[i].compactUrl;
+                else                      j.url = i;
+                if (options.includeTypes) j.type = failed[i].type;
+                result.error.push(j);
+            }
+        }
+        if (callback) {
+            callback(result);
+        } else {
+            console.log(JSON.stringify(result, null, 2));
+        }
+    } else if ("plain" === options.format) {
+        result = '';
+        for (i in found) {
+            if (options.compactUrls)  result += found[i].compactUrl + ' ok';
+            else                      result += i + ' ok';
+            if (options.includeTypes) result += ' ' + found[i].type;
+            result += '\n';
+        }
+        if (options.includeErrors) {
+            for (i in failed) {
+                if (options.compactUrls)  result += failed[i].compactUrl + ' error';
+                else                      result += i + ' error';
+                if (options.includeTypes) result += ' ' + failed[i].type;
+                result += '\n';
+            }
+        }
+        if (callback) {
+            callback(result);
+        } else {
+            console.log(result);
+        }
+    }
+};
+
+ var getMetadata = function(res) {
+    var compactUrl = u.parse(res.url).href.replace(baseUrl, '')
+    ,   type = '[unknown]'
+    ;
+    if (res.status && 200 === res.status) {
+        if      (/text\/html?/i                        .test(res.contentType)) type = 'html';
+        else if (/text\/css/i                          .test(res.contentType)) type = 'css';
+        else if (/image\/\w+/i                         .test(res.contentType)) type = 'img';
+        else if (/(application|text)\/(javascript|js)/i.test(res.contentType)) type = 'js';
+        else                                                                   type = 'js';
+    }
+    return {compactUrl: compactUrl, type: type};
+};
+
+var processRequest = function(res) {
+    pending ++;
+};
+
+var processResult = function(res) {
+    if (res && res.status && res.stage && 'end' === res.stage) {
+        if (200 === res.status) {
+            found[res.url] = getMetadata(res);
+            pending --;
+        } else if (404 === res.status) {
+            failed[res.url] = getMetadata(res);
+            pending --;
+        }
+        if (0 === pending) dumpResult();
+    }
+};
+
+exports.run = function (url, opts, cb) {
+    document = url;
+    baseUrl = document.replace(/[^\/]*$/, "");
+    options = JSON.parse(JSON.stringify(DEFAULT_OPTIONS));
+    if (opts) {
+        if (opts.hasOwnProperty("format"))        options.format        = opts.format;
+        if (opts.hasOwnProperty("compactUrls"))   options.compactUrls   = opts.compactUrls;
+        if (opts.hasOwnProperty("includeErrors")) options.includeErrors = opts.includeErrors;
+        if (opts.hasOwnProperty("includeTypes"))  options.includeTypes  = opts.includeTypes;
+    }
+    callback = cb;
+    found = {};
+    failed = {};
+    pending = 0;
+    var nm = new Nightmare({
+        phantomPath: pth.dirname(phantomjs.path) + "/"
     });
-    nm.goto(loadURL);
+    nm.on("resourceRequested", processRequest);
+    nm.on("resourceReceived",  processResult);
+    nm.on("resourceError",     processResult);
+    nm.goto(document);
     nm.run();
 };
 
 // running directly
 if (!module.parent) {
-    var source = process.argv[2];
-    if (!source) console.error("Usage: echidna-manifester [PATH or URL]");
+    var source = process.argv[2]
+    , opts
+    ;
+    if (process.argv.length > 3) {
+        opts = JSON.parse(process.argv[3]);
+    }
+    if (!source) console.error("Usage: echidna-manifester <PATH-or-URL> [OPTIONS-as-json]");
     // if path is a file, make a URL from it
     if (!/^\w+:/.test(source)) source = "file://" + pth.join(process.cwd(), source);
-    exports.run(source);
+    exports.run(source, opts);
 }
+

--- a/package.json
+++ b/package.json
@@ -1,8 +1,29 @@
 {
   "name": "echidna-manifester",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "license": "MIT",
+  "description": "Load a file you give to it (local or URL) and list all linked resources",
+  "author": "W3C",
+  "contributors": [
+    {
+      "name": "Robin Berjon",
+      "email": "robin@w3.org"
+    },
+    {
+      "name": "Antonio Olmo Titos",
+      "email": "antonio@w3.org"
+    }
+  ],
+  "keywords": [
+    "w3c",
+    "publication",
+    "echidna",
+    "manifest"
+  ],
   "repository": "git@github.com:darobin/echidna-manifester.git",
+  "bugs": {
+    "url": "https://github.com/darobin/echidna-manifester/issues"
+  },
   "dependencies": {
     "nightmare": "^1.8.2",
     "nopt": "^3.0.1",


### PR DESCRIPTION
We might start using `echidna-manifester` within Echidna, as a Node.js module, so that editors can forget about writing manifests (ideally; we'll see). This PR adds a few options to the tool.

These are several different changes, but it was easier to submit just one PR than to try to keep them separated. Refer to [the new README](https://github.com/tripu/echidna-manifester/blob/master/README.md#installation) for details about what's new.

(I think that with these changes, the tool becomes more versatile, and it could be useful for other purposes. Maybe we'll give it a more generic name in the future&hellip;?)

This fixes #1 :¬)
